### PR TITLE
Fix for Python >= 3.3

### DIFF
--- a/logaugment/__init__.py
+++ b/logaugment/__init__.py
@@ -1,8 +1,12 @@
-import collections
 import logging
+import sys
+if sys.version_info.major >= 3 and sys.version_info.minor >= 3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
 
 __title__ = 'logaugment'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __author__ = 'Simeon Visser'
 __email__ = 'simeonvisser@gmail.com'
 __license__ = 'MIT'

--- a/logaugment/__init__.py
+++ b/logaugment/__init__.py
@@ -26,7 +26,7 @@ class AugmentFilter(logging.Filter):
                 data = self._args(record)
             except TypeError:
                 pass
-            if not data and isinstance(self._args, collections.Mapping):
+            if not data and isinstance(self._args, Mapping):
                 data = self._args
             if data and not hasattr(record, '_logaugment'):
                 record._logaugment = {}

--- a/logaugment/__init__.py
+++ b/logaugment/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-if sys.version_info.major >= 3 and sys.version_info.minor >= 3:
+if (sys.version_info.major, sys.version_info.minor) >= (3, 3):
     from collections.abc import Mapping
 else:
     from collections import Mapping


### PR DESCRIPTION
Since Python3.3, `collections.Mapping` has been moved to `collections.abc.Mapping`. The old location was finally deprecated in Python 3.10.

This PR does the following:
 - Checks whether the Python version is at least 3.3.
 - If it is, import from `Mapping` from `collections.abc` instead of `collections`.
 - Increment the version from 0.1.3 to 0.1.4.